### PR TITLE
ReplayDataType.stats does not exist

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -51,8 +51,8 @@ const StatusString = {
 }
 
 // it's everything except gameevents which is just a massive amount of data
-const CommonReplayData = [ReplayDataType.message, ReplayDataType.tracker, ReplayDataType.attribute, ReplayDataType.header, ReplayDataType.details, ReplayDataType.init, ReplayDataType.stats];
-const AllReplayData = [ReplayDataType.game, ReplayDataType.message, ReplayDataType.tracker, ReplayDataType.attribute, ReplayDataType.header, ReplayDataType.details, ReplayDataType.init, ReplayDataType.stats];
+const CommonReplayData = [ReplayDataType.message, ReplayDataType.tracker, ReplayDataType.attribute, ReplayDataType.header, ReplayDataType.details, ReplayDataType.init];
+const AllReplayData = [ReplayDataType.game, ReplayDataType.message, ReplayDataType.tracker, ReplayDataType.attribute, ReplayDataType.header, ReplayDataType.details, ReplayDataType.init];
 
 function parse(file, requestedData, opts) {
   var replay = {};


### PR DESCRIPTION
ReplayDataType.stats does not exist, and the new version of heroprotocol.js will return error messages.

Sorry, Github web-edit converts EOFs