### PR TITLE
Add selections (bans and picks) in draft order

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -627,6 +627,41 @@ function processReplay(file, opts = {}) {
       log.debug('Draft data complete');
     }
 
+    let a = 1;
+    let b = 0;
+    // check if Blue Team has first pick
+    if (match.picks.first === 0) {
+      [a, b] = [b, a];
+    }
+
+    // create a list of bans and picks in draft order
+    let selections = [];
+
+    selections.push(match.bans[a][0]);
+    selections.push(match.bans[b][0]);
+    selections.push(match.bans[a][1]);
+    selections.push(match.bans[b][1]);
+
+    selections.push(match.picks[a][0]);
+    selections.push(match.picks[b][0]);
+    selections.push(match.picks[b][1]);
+    selections.push(match.picks[a][1]);
+    selections.push(match.picks[a][2]);
+
+    selections.push(match.bans[b][2]);
+    selections.push(match.bans[a][2]);
+
+    selections.push(match.picks[b][2]);
+    selections.push(match.picks[b][3]);
+    selections.push(match.picks[a][3]);
+    selections.push(match.picks[a][4]);
+    selections.push(match.picks[b][4]);
+
+    // get the slot number for each hero
+    for (const [id, player] of Object.entries(players)) {
+      player.turn = selections.indexOf(player.hero);
+    }
+
     // the tracker events have most of the useful data
     // track a few different kinds of things here, this is probably where most of the interesting stuff will come from
     match.XPBreakdown = [];


### PR DESCRIPTION
This change is meant to create an easy-to-access list of selections (bans and picks) in draft order.

I will also make a pull request to include them in the CSV file with Hero Details in Stats of the Storm.