### PR TITLE
Add check for games without a second early ban

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -639,8 +639,15 @@ function processReplay(file, opts = {}) {
 
     selections.push(match.bans[a][0]);
     selections.push(match.bans[b][0]);
-    selections.push(match.bans[a][1]);
-    selections.push(match.bans[b][1]);
+
+    // check if the game is from before the second early ban was added
+    if (match.version.m_build < 66292) {
+      selections.push("N/A");
+      selections.push("N/A");
+    } else {
+      selections.push(match.bans[a][1]);
+      selections.push(match.bans[b][1]);
+    }
 
     selections.push(match.picks[a][0]);
     selections.push(match.picks[b][0]);
@@ -648,8 +655,14 @@ function processReplay(file, opts = {}) {
     selections.push(match.picks[a][1]);
     selections.push(match.picks[a][2]);
 
-    selections.push(match.bans[b][2]);
-    selections.push(match.bans[a][2]);
+    // check if the game is from before the second early ban was added
+    if (match.version.m_build < 66292) {
+      selections.push(match.bans[b][1]);
+      selections.push(match.bans[a][1]);
+    } else {
+      selections.push(match.bans[b][2]);
+      selections.push(match.bans[a][2]);
+    }
 
     selections.push(match.picks[b][2]);
     selections.push(match.picks[b][3]);


### PR DESCRIPTION
I'm adding a check to see if there isn't a second early ban while adding bans to the list of selections because otherwise that list is being built incorrectly (that is, the middle ban is counted as second early ban) and it also causes loading issues while trying to look at the match details for these games.