### PR TITLE
fix: parser assigning incorrect tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "hots-parser",
-  "version": "7.55.1",
+  "version": "7.55.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "7.55.1",
+      "name": "hots-parser",
+      "version": "7.55.6",
       "license": "MIT",
       "dependencies": {
         "heroprotocol": "GaryIrick/heroprotocol",


### PR DESCRIPTION
This fixes incorrect tags caused by having two players with the same name in the same game.
It would also be caused if one of the observers had the same name as a person in the game.

This happened with these accounts for me:
![image](https://github.com/user-attachments/assets/326a053c-a378-4cfd-b007-fbc3e85514e4)
(before I fixed this, these two accounts would show the same tag)